### PR TITLE
Allow changing of non-uniform MISC values

### DIFF
--- a/xl710_unlock.c
+++ b/xl710_unlock.c
@@ -173,7 +173,7 @@ int main(int argc, char *const *argv) {
         ifr.ifr_data = (void*)eeprom;
         if (ioctl(fd, SIOCETHTOOL, &ifr) == -1) die("write");
       } else {
-        printf("not changing, already unlocked at this misc 0x%04x", *(uint16_t*)(eeprom + 1));
+        printf("not changing, already unlocked in PHY struct %d at offset 0x%04x\n", i, ((phy_offset + ((phy_cap_size + 1) * i))));
       }
       sleep(1);
     }

--- a/xl710_unlock.c
+++ b/xl710_unlock.c
@@ -143,7 +143,7 @@ int main(int argc, char *const *argv) {
     }
   }
 
-  if( change_count > 1 ) die( "Different MISC's values" );
+  if( change_count > 1 ) printf("Warning: different MISC values\n");;
 
   /*
     Patching
@@ -168,10 +168,13 @@ int main(int argc, char *const *argv) {
       eeprom->cmd = ETHTOOL_SEEPROM;
       eeprom->offset = (phy_offset + misc_offset + (phy_cap_size + 1) * i) << 1;
 
-      *(uint16_t*)(eeprom + 1) = misc0 ^ 0x0800;
-      ifr.ifr_data = (void*)eeprom;
-      if (ioctl(fd, SIOCETHTOOL, &ifr) == -1) die("write");
-
+      if(misc0 & 0x0800){ // if locked
+        *(uint16_t*)(eeprom + 1) = misc0 ^ 0x0800;
+        ifr.ifr_data = (void*)eeprom;
+        if (ioctl(fd, SIOCETHTOOL, &ifr) == -1) die("write");
+      } else {
+        printf("not changing, already unlocked at this misc 0x%04x", *(uint16_t*)(eeprom + 1));
+      }
       sleep(1);
     }
 


### PR DESCRIPTION
Ran into issues when one of my MISC values at the first PHY struct was already unlocked.

This fix should allow people to still unlock the rest of the ports, even if they already have one or more unlocked. Not sure what the previous reason for only doing all-or-nothing was -- perhaps someone can enlighten me.

Tested and working with a locked port and an already unlocked port situation.